### PR TITLE
run route-sync tests as part of CI test script

### DIFF
--- a/script/run_tests
+++ b/script/run_tests
@@ -1,5 +1,21 @@
-#!/bin/bash
+#!/bin/bash -e
+[ -z "$DEBUG" ] || set -x
 
-# There's no code in this release, so no tests as yet
+project_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+
+test_route_sync() {
+  pushd "${project_root}/src/route-sync" > /dev/null
+    export GOPATH=${project_root}
+    echo "Running ginkgo"
+    ginkgo -r .
+    echo "Running ginkgo to check race conditions"
+    ginkgo -r -race .
+    echo "Compiling final binary"
+    go build
+  popd > /dev/null
+}
+
+
+test_route_sync
 
 exit 0


### PR DESCRIPTION
***trying out PR on a PR to see how that feels***

This script is expected to run under the `pcfkubo/kubo-ci` docker image by CI which
contains the appropriate version of go and ginkgo. It can also be used
by local developers for inner loop testing.

The following is validated by this change:
 - ginkgo -r .: correctness of the tests
 - ginkgo -r -race .: no observable race conditions
 - go build: entire package compiles to exercise not tested code (eg
   main.go). We want to add test coverage to our main code but there
   will always be an entry point that can only be validated by
   compilation.

[#137357741]