### PR TITLE
Prevent KubeDNS crashes

### DIFF
--- a/jobs/kubernetes-system-specs/spec
+++ b/jobs/kubernetes-system-specs/spec
@@ -3,7 +3,8 @@ name: kubernetes-system-specs
 
 templates:
   bin/post-deploy: bin/post-deploy
-  config/kubedns.yml: config/kubedns.yml
+  config/kubedns-svc.yml: config/kubedns-svc.yml
+  config/kubedns-rc.yml: config/kubedns-rc.yml
   config/influxdb.yml: config/influxdb.yml
   config/heapster.yml.erb: config/heapster.yml
   config/kubernetes-dashboard.yml: config/kubernetes-dashboard.yml

--- a/jobs/kubernetes-system-specs/spec
+++ b/jobs/kubernetes-system-specs/spec
@@ -3,13 +3,16 @@ name: kubernetes-system-specs
 
 templates:
   bin/post-deploy: bin/post-deploy
+  bin/ensure-specs-running: bin/ensure-specs-running
   config/kubedns-svc.yml: config/kubedns-svc.yml
   config/kubedns-rc.yml: config/kubedns-rc.yml
   config/influxdb.yml: config/influxdb.yml
   config/heapster.yml.erb: config/heapster.yml
   config/kubernetes-dashboard.yml: config/kubernetes-dashboard.yml
 
-packages: []
+packages:
+- jq
+- kubernetes
 
 properties:
   kubernetes-api-url:

--- a/jobs/kubernetes-system-specs/templates/bin/ensure-specs-running
+++ b/jobs/kubernetes-system-specs/templates/bin/ensure-specs-running
@@ -1,0 +1,26 @@
+#!/bin/bash -ex
+
+kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
+jq="/var/vcap/packages/jq/bin/jq"
+expected_pods=6
+
+function specs_ready() {
+  pods_deployed=$(${kubectl} get pods --namespace=kube-system -o json | ${jq} '.items[].status.containerStatuses[].ready' | wc -l)
+  pods_ready=$(${kubectl} get pods --namespace=kube-system -o json | ${jq} '.items[].status.containerStatuses[].ready | select(. == true)' | wc -l)
+
+  if [ "${pods_deployed}" -ne "${expected_pods}" ]; then
+    echo "ensure-specs-running failure: Number of pods deployed"
+    return 1
+  fi
+
+  if [ "${pods_ready}" -ne "${expected_pods}" ]; then
+    echo "ensure-specs-running failure: Deployed pods that are 'Ready'"
+    return 1
+  fi
+
+  return 0
+}
+
+until specs_ready; do
+  sleep 2
+done

--- a/jobs/kubernetes-system-specs/templates/bin/post-deploy
+++ b/jobs/kubernetes-system-specs/templates/bin/post-deploy
@@ -5,11 +5,12 @@ kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/k
 
 apply_spec() {
   local spec="$1"
-  ${kubectl} apply -f ${spec_dir}/${spec} || echo "${spec} was already deployed"
+  ${kubectl} apply -f "${spec_dir}/${spec}" || echo "${spec} was already deployed"
 }
 
 deploy_specs() {
-  apply_spec "kubedns.yml"
+  apply_spec "kubedns-svc.yml"
+  apply_spec "kubedns-rc.yml"
   apply_spec "influxdb.yml"
   apply_spec "heapster.yml"
   apply_spec "kubernetes-dashboard.yml"

--- a/jobs/kubernetes-system-specs/templates/bin/post-deploy
+++ b/jobs/kubernetes-system-specs/templates/bin/post-deploy
@@ -3,6 +3,8 @@
 spec_dir="/var/vcap/jobs/kubernetes-system-specs/config/"
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
 
+TIMEOUT=120
+
 apply_spec() {
   local spec="$1"
   ${kubectl} apply -f "${spec_dir}/${spec}" || echo "${spec} was already deployed"
@@ -16,8 +18,19 @@ deploy_specs() {
   apply_spec "kubernetes-dashboard.yml"
 }
 
+verify_specs() {
+  if timeout "$TIMEOUT" /var/vcap/jobs/kubernetes-system-specs/bin/ensure-specs-running
+  then
+    echo "all expected specs are running"
+  else
+    echo "failed to start all system specs after $TIMEOUT"
+    exit 1
+  fi
+}
+
 main() {
   deploy_specs
+  verify_specs
 }
 
 main

--- a/jobs/kubernetes-system-specs/templates/config/kubedns-rc.yml
+++ b/jobs/kubernetes-system-specs/templates/config/kubedns-rc.yml
@@ -1,53 +1,40 @@
-apiVersion: v1
-kind: Service
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: kube-dns
   namespace: kube-system
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
-    kubernetes.io/name: "KubeDNS"
 spec:
   selector:
-    k8s-app: kube-dns
-  clusterIP: 10.100.200.10
-  ports:
-  - name: dns
-    port: 53
-    protocol: UDP
-  - name: dns-tcp
-    port: 53
-    protocol: TCP
-
----
-
-apiVersion: v1
-kind: ReplicationController
-metadata:
-  name: kube-dns-v19
-  namespace: kube-system
-  labels:
-    k8s-app: kube-dns
-    version: v19
-    kubernetes.io/cluster-service: "true"
-spec:
-  replicas: 1
-  selector:
-    k8s-app: kube-dns
-    version: v19
+    matchLabels:
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v19
-        kubernetes.io/cluster-service: "true"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
         scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/kubedns-amd64:1.7
+        image: gcr.io/google_containers/kubedns-amd64:1.8
         imagePullPolicy: IfNotPresent
         resources:
           # TODO: Set memory limits when we've profiled the container for large
@@ -61,7 +48,7 @@ spec:
             memory: 70Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -71,7 +58,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readiness
-            port: 8080
+            port: 8081
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
@@ -79,7 +66,7 @@ spec:
           timeoutSeconds: 5
         args:
         # command = "/kube-dns"
-        - --domain=cluster.local
+        - --domain=cluster.local.
         - --dns-port=10053
         - --kubecfg-file=/var/vcap/jobs/kubeconfig/config/kubeconfig
         ports:
@@ -93,11 +80,22 @@ spec:
         - name: config
           mountPath: /var/vcap/jobs/kubeconfig/config/
       - name: dnsmasq
-        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.3
+        image: gcr.io/google_containers/kube-dnsmasq-amd64:1.4.1
         imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
+        - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns
@@ -106,7 +104,7 @@ spec:
           name: dns-tcp
           protocol: TCP
       - name: healthz
-        image: gcr.io/google_containers/exechealthz-amd64:1.1
+        image: gcr.io/google_containers/exechealthz-amd64:1.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -119,13 +117,16 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
-        - -port=8080
-        - -quiet
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP
-      dnsPolicy: Default  # Don't use cluster DNS.
+      dnsPolicy: Default  
       volumes:
       - name: config
         hostPath:

--- a/jobs/kubernetes-system-specs/templates/config/kubedns-svc.yml
+++ b/jobs/kubernetes-system-specs/templates/config/kubedns-svc.yml
@@ -1,0 +1,34 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "KubeDNS"
+spec:
+  selector:
+    k8s-app: kube-dns
+  clusterIP: 10.100.200.10
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP


### PR DESCRIPTION
KubeDNS is not properly working today. When the service is deployed the healthz check never succeeds. Sometimes after fiddling with replications the service does come online but it's not consistent.

Issues we've observed:
- Crashes on start
- Multiple unique pods deployed (kubedns-foo, kubedns-bar)

This change regenerates the kubedns manifests from the kubernetes repo and changes the `ReplicationController` to a `Deployment` which fixes the multiple pod issue. The separation of the service and the pod deployment fixes the crashing. 

A check is added to the post-deploy to verify all system specs are running before marking the deployment a success. 