### PR TITLE
Fixing bug so that logs are viewable on k8s dashboard

### DIFF
--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -63,7 +63,7 @@ check_if_pidfile_exists() {
 }
 
 drain_kubelet() {
-  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.address %> --grace-period 10 --force --delete-local-data
+  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.ip %> --grace-period 10 --force --delete-local-data
 }
 
 kill_node() {

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -63,7 +63,7 @@ check_if_pidfile_exists() {
 }
 
 drain_kubelet() {
-  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.id %> --grace-period 10 --force --delete-local-data
+  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.address %> --grace-period 10 --force --delete-local-data
 }
 
 kill_node() {

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -63,7 +63,7 @@ check_if_pidfile_exists() {
 }
 
 drain_kubelet() {
-  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain $(hostname -I | awk '{print $1}') --grace-period 10 --force --delete-local-data
+  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.id %> --grace-period 10 --force --delete-local-data
 }
 
 kill_node() {

--- a/jobs/kubelet/templates/bin/drain.erb
+++ b/jobs/kubelet/templates/bin/drain.erb
@@ -63,7 +63,7 @@ check_if_pidfile_exists() {
 }
 
 drain_kubelet() {
-  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain <%= spec.id %> --grace-period 10 --force --delete-local-data
+  kubectl --kubeconfig /var/vcap/jobs/kubeconfig/config/kubeconfig drain $(hostname -I | awk '{print $1}') --grace-period 10 --force --delete-local-data
 }
 
 kill_node() {

--- a/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
+++ b/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.id %>
+node_name=<%= spec.address %>
 
 # Wait for kubelet to become Ready before we move on to the next node.
 # Scheduling might not be enabled at this time.

--- a/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
+++ b/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=$(hostname -I | awk '{print $1}')
+node_name=<%= spec.id %>
 
 # Wait for kubelet to become Ready before we move on to the next node.
 # Scheduling might not be enabled at this time.

--- a/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
+++ b/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.address %>
+node_name=<%= spec.ip %>
 
 # Wait for kubelet to become Ready before we move on to the next node.
 # Scheduling might not be enabled at this time.

--- a/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
+++ b/jobs/kubelet/templates/bin/ensure_kubelet_up_and_running.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.id %>
+node_name=$(hostname -I | awk '{print $1}')
 
 # Wait for kubelet to become Ready before we move on to the next node.
 # Scheduling might not be enabled at this time.

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -39,7 +39,7 @@ start_kubelet() {
     --container-runtime=docker \
     --docker="${DOCKER_SOCKET}" \
     --docker-endpoint="${DOCKER_SOCKET}" \
-    --hostname-override="<%= spec.id %>" \
+    --hostname-override="<%= spec.address %>" \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --non-masquerade-cidr 10.200.0.0/16 \
     --serialize-image-pulls=false \

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -39,7 +39,7 @@ start_kubelet() {
     --container-runtime=docker \
     --docker="${DOCKER_SOCKET}" \
     --docker-endpoint="${DOCKER_SOCKET}" \
-    --hostname-override="<%= spec.address %>" \
+    --hostname-override="<%= spec.ip %>" \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --non-masquerade-cidr 10.200.0.0/16 \
     --serialize-image-pulls=false \

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -30,6 +30,8 @@ start_kubelet() {
 
   ln -s -f /var/vcap/jobs/kubelet/packages/cni/bin/nsenter /usr/bin/nsenter
 
+  node_name=$(hostname -I | awk '{print $1}')
+
   kubelet \
     --allow-privileged=true \
     --api-servers=<%= p("kubernetes-api-url") %> \
@@ -39,7 +41,7 @@ start_kubelet() {
     --container-runtime=docker \
     --docker="${DOCKER_SOCKET}" \
     --docker-endpoint="${DOCKER_SOCKET}" \
-    --hostname-override="<%= spec.id %>" \
+    --hostname-override="${node_name}" \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --non-masquerade-cidr 10.200.0.0/16 \
     --serialize-image-pulls=false \

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -30,8 +30,6 @@ start_kubelet() {
 
   ln -s -f /var/vcap/jobs/kubelet/packages/cni/bin/nsenter /usr/bin/nsenter
 
-  node_name=$(hostname -I | awk '{print $1}')
-
   kubelet \
     --allow-privileged=true \
     --api-servers=<%= p("kubernetes-api-url") %> \
@@ -41,7 +39,7 @@ start_kubelet() {
     --container-runtime=docker \
     --docker="${DOCKER_SOCKET}" \
     --docker-endpoint="${DOCKER_SOCKET}" \
-    --hostname-override="${node_name}" \
+    --hostname-override="<%= spec.id %>" \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --non-masquerade-cidr 10.200.0.0/16 \
     --serialize-image-pulls=false \

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=$(hostname -I | awk '{print $1}')
+node_name=<%= spec.id %>
 
 # Deleting docker0 route as a workaround to a routing conflict
 # between the docker0 bridge and the CNI interface

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.address %>
+node_name=<%= spec.ip %>
 
 # Deleting docker0 route as a workaround to a routing conflict
 # between the docker0 bridge and the CNI interface

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.id %>
+node_name=<%= spec.address %>
 
 # Deleting docker0 route as a workaround to a routing conflict
 # between the docker0 bridge and the CNI interface

--- a/jobs/kubelet/templates/bin/post-start.erb
+++ b/jobs/kubelet/templates/bin/post-start.erb
@@ -3,7 +3,7 @@
 [ -z "$DEBUG" ] || set -x
 
 kubectl="/var/vcap/packages/kubernetes/bin/kubectl --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig"
-node_name=<%= spec.id %>
+node_name=$(hostname -I | awk '{print $1}')
 
 # Deleting docker0 route as a workaround to a routing conflict
 # between the docker0 bridge and the CNI interface

--- a/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
+++ b/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
@@ -28,7 +28,7 @@ start_kubernetes_proxy() {
 
 
   kube-proxy \
-    --hostname-override=<%= spec.address %> \
+    --hostname-override=<%= spec.ip %> \
     --master=<%= p("kubernetes-api-url") %> \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --proxy-mode=iptables \

--- a/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
+++ b/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
@@ -26,10 +26,9 @@ send_process_stderr_to_logfile() {
 
 start_kubernetes_proxy() {
 
-  node_name=$(hostname -I | awk '{print $1}') 
 
   kube-proxy \
-    --hostname-override="${node_name}" \
+    --hostname-override=<%= spec.address %> \
     --master=<%= p("kubernetes-api-url") %> \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --proxy-mode=iptables \

--- a/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
+++ b/jobs/kubernetes-proxy/templates/bin/kubernetes_proxy_ctl.erb
@@ -26,9 +26,10 @@ send_process_stderr_to_logfile() {
 
 start_kubernetes_proxy() {
 
+  node_name=$(hostname -I | awk '{print $1}') 
 
   kube-proxy \
-    --hostname-override=<%= spec.address %> \
+    --hostname-override="${node_name}" \
     --master=<%= p("kubernetes-api-url") %> \
     --kubeconfig=/var/vcap/jobs/kubeconfig/config/kubeconfig \
     --proxy-mode=iptables \


### PR DESCRIPTION
Changing worker node name to internal ip address of node so that master can resolve it as a hostname

Even though we are using dynamic networking, the ip address has already been assigned by the time these scripts run, because we run kubelet and kube-proxy on the worker vms. We can get the internal ip addresses using `hostname -I`. 

[#139275251]