### PR TITLE
Use the etcd v3 storage backend for the API server

### DIFF
--- a/jobs/kubernetes-api/templates/bin/kubernetes_api_ctl.erb
+++ b/jobs/kubernetes-api/templates/bin/kubernetes_api_ctl.erb
@@ -53,7 +53,6 @@ start_kubernetes_api_server() {
       --tls-cert-file=/var/vcap/jobs/kubernetes-api/config/kubernetes.pem \
       --tls-private-key-file=/var/vcap/jobs/kubernetes-api/config/kubernetes-key.pem \
       --token-auth-file=/var/vcap/jobs/kubernetes-api/config/tokens.csv \
-      --storage-backend=etcd2 \
       --storage-media-type=application/json \
       --v=2 \
     1>> $LOG_DIR/kubernetes_api.stdout.log \


### PR DESCRIPTION
Now that our forked etcd-release provides a v3 release of etcd, remove the compatibility mode from the kubernetes API server.

**Breaking Change**: This change requires an updated version of etcd-release to be deployed with kubo that provides a v3 compatible API.

Do not merge before: [kubo-deployment PR #104](https://github.com/pivotal-cf-experimental/kubo-deployment/pull/104)

[#141623859]